### PR TITLE
fix: act claim chaining

### DIFF
--- a/src/Farfetch.IdentityServer.Contrib.TokenExchange/Models/ActClaim.cs
+++ b/src/Farfetch.IdentityServer.Contrib.TokenExchange/Models/ActClaim.cs
@@ -1,0 +1,10 @@
+﻿namespace IdentityServer4.Contrib.TokenExchange.Models
+{
+    using Newtonsoft.Json;
+
+    public class ActClaim
+    {
+        [JsonProperty(PropertyName = "client_id")]
+        public string LastClientId { get; set; }
+    }
+}


### PR DESCRIPTION
This MR fixes the Act claim chaining when the client_id is the same.
