### PR TITLE
Fix/act claim duplicate issues

### DIFF
--- a/src/Farfetch.IdentityServer.Contrib.TokenExchange/Builders/TokenExchangeResultBuilder.cs
+++ b/src/Farfetch.IdentityServer.Contrib.TokenExchange/Builders/TokenExchangeResultBuilder.cs
@@ -161,9 +161,9 @@
             act.TryAddNonEmptyJObject(TokenExchangeConstants.ClaimTypes.Act, GetFromExistingClaim(TokenExchangeConstants.ClaimTypes.Act, this.subjectUserClaims.Act()));
 
             var newAct = new Claim(
-                TokenExchangeConstants.ClaimTypes.Act,
-                JsonConvert.SerializeObject(act, this.jsonSettings),
-                IdentityServerConstants.ClaimValueTypes.Json
+                        TokenExchangeConstants.ClaimTypes.Act,
+                        JsonConvert.SerializeObject(act, this.jsonSettings),
+                        IdentityServerConstants.ClaimValueTypes.Json
                 );
 
             this.subjectUserClaims.Add(newAct);

--- a/src/Farfetch.IdentityServer.Contrib.TokenExchange/Extensions/DictionaryExtensions.cs
+++ b/src/Farfetch.IdentityServer.Contrib.TokenExchange/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,43 @@
+﻿namespace Farfetch.IdentityServer.Contrib.TokenExchange.Extensions
+{
+    using System.Collections.Generic;
+
+    using Newtonsoft.Json.Linq;
+
+    public static class DictionaryExtensions
+    {
+        public static bool TryAddNonEmptyString(this Dictionary<string, object> dictionary, string key, string value)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            dictionary.Add(key, value);
+
+            return true;
+        }
+
+        public static bool TryAddNonEmptyJObject(this Dictionary<string, object> dictionary, string key, JObject value)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                return false;
+            }
+
+            if (!value.HasValues)
+            {
+                return false;
+            }
+
+            dictionary.Add(key, value);
+
+            return true;
+        }
+    }
+}

--- a/src/Farfetch.IdentityServer.Contrib.TokenExchange/Models/ActClaim.cs
+++ b/src/Farfetch.IdentityServer.Contrib.TokenExchange/Models/ActClaim.cs
@@ -5,6 +5,6 @@
     public class ActClaim
     {
         [JsonProperty(PropertyName = "client_id")]
-        public string LastClientId { get; set; }
+        public string ClientId { get; set; }
     }
 }

--- a/tests/Farfetch.IdentityServer.Contrib.TokenExchange.Tests/Builder/TestConstants.cs
+++ b/tests/Farfetch.IdentityServer.Contrib.TokenExchange.Tests/Builder/TestConstants.cs
@@ -1,0 +1,27 @@
+namespace Farfetch.IdentityServer.Contrib.TokenExchange.Tests.Builder
+{
+    
+    public static class TestConstants
+    {
+        // Act Claim
+        public const string ExpectedActClaim =
+            "{\"sub\":\"subActor\",\"tenantId\":\"1\",\"client_id\":\"client_id_from_actor\",\"act\":{\"client_id\":\"api1\",\"act\":{\"client_id\":\"api2\"}}}";
+
+        public const string SubjectActClaim =
+            "{\"client_id\":\"api1\",\"act\":{\"client_id\":\"api2\"}}";
+
+        public const string SubjectActClaimWithSameClientIdAtLast =
+            "{\"sub\":\"subActor\",\"tenantId\":\"1\",\"client_id\":\"client_id_from_actor\",\"act\":{\"client_id\":\"api1\",\"act\":{\"client_id\":\"api2\"}}}";
+
+        // Client Act Claim
+        public const string ExpectedClientActClaim =
+            "{\"tenantId\":\"1\",\"client_id\":\"client_id_from_actor\",\"client_act\":{\"client_id\":\"api1\",\"client_act\":{\"client_id\":\"api2\"}}}";
+
+        public const string SubjectClientActClaim =
+            "{\"client_id\":\"api1\",\"client_act\":{\"client_id\":\"api2\"}}";
+
+        public const string SubjectClientActClaimWithSameClientIdAtLast =
+            "{\"tenantId\":\"1\",\"client_id\":\"client_id_from_actor\",\"client_act\":{\"client_id\":\"api1\",\"client_act\":{\"client_id\":\"api2\"}}}";
+
+    }
+}


### PR DESCRIPTION
# PR Details

This PR fix the Act and Client Act claim chaining issue.

## Description

**Situation** 
The "act" and "client_secret" claim has its content duplicated for the same "client_id" when the last "client_id" is the same of the current "actor_token".